### PR TITLE
Build libcanard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ cmake_minimum_required(VERSION 3.5)
 
 project(STG-8nn-Scaffold C ASM)
 
-set(GENERIC_C_FLAGS "-Wall -Wextra -Wredundant-decls -Wmissing-prototypes -Wimplicit-function-declaration -Wshadow -Wno-unused-parameter -ffunction-sections -fdata-sections")
+set(GENERIC_C_FLAGS "-Wall -Wextra -Wredundant-decls -Wmissing-prototypes -Wimplicit-function-declaration -Wshadow -Wno-unused-parameter -Wdouble-promotion -Wswitch-enum -Wfloat-equal -Wconversion -Wtype-limits -Wsign-conversion -Wcast-align -Wmissing-declarations -ffunction-sections -fdata-sections")
 
 if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm")
   #
@@ -39,11 +39,19 @@ if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm")
   #
   # Flags for use with Clang's ARM Toolchain
   #
-  else("${CMAKE_ASM_COMPILER_ID}" MATCHES "Clang")
+  elseif("${CMAKE_ASM_COMPILER_ID}" MATCHES "Clang")
     set(MCU_FLAGS "--target=armv6m-unknown-none-eabi -march=armv6m -mthumb -mcpu=cortex-m0 -mfloat-abi=soft -mfpu=none")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${MCU_FLAGS} -Wno-unused-command-line-argument -ffreestanding ${GENERIC_C_FLAGS}")
     set(CMAKE_EXE_LINKER_FLAGS "${MCU_FLAGS} --static -specs=nosys.specs -Tstg8nn.ld -Wl,--cref,--gc-sections,-Map=stg8nn.map")
   endif()
+else()
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pedantic ${GENERIC_C_FLAGS}")
+    set(CMAKE_ASM_FLAGS "-Wall -fdata-sections -ffunction-sections")
+    if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
+      set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -m32")
+      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -m32")
+    endif()
 endif()
 
 if(NOT CMAKE_BUILD_TYPE)
@@ -56,6 +64,11 @@ endif()
 set(CMAKE_C_STANDARD 99)
 
 set(BUILD_SHARED_LIBS OFF)
+
+##
+## Some diagnostic messages
+##
+message(STATUS "System: ${CMAKE_SYSTEM_NAME}")
 
 ##
 ## Configure build
@@ -80,6 +93,14 @@ endif()
 include(CMakeLists_qpc.txt)
 list(APPEND STG8NN_SOURCES ${QPC_SOURCES})
 list(APPEND STG8NN_INCLUDE ${QPC_INCLUDE})
+
+##
+## dependencies::libcanard
+##
+
+include(CMakeLists_libcanard.txt)
+list(APPEND STG8NN_SOURCES ${CANARD_SOURCES})
+list(APPEND STG8NN_INCLUDE ${CANARD_INCLUDE})
 
 ##
 ## bsp
@@ -128,7 +149,5 @@ endif()
 ## tester libraries
 ##
 if(NOT "${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm")
-  set(THREADS_PREFER_PTHREAD_FLAG ON)
-  find_package(Threads REQUIRED)
-  target_link_libraries(${OUTPUT_NAME}.elf Threads::Threads)
+  target_link_libraries(${OUTPUT_NAME}.elf pthread)
 endif()

--- a/CMakeLists_libcanard.txt
+++ b/CMakeLists_libcanard.txt
@@ -19,6 +19,12 @@
 ## dependencies::libcanard
 ##
 
+# Darwin (macOS) is not yet supported with CAN
+if("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
+  message(WARNING "Darwin lacks a CAN driver for libcanard")
+  return()
+endif()
+
 set(CANARD_DIR dependencies/libcanard)
 set(CANARD_LIBRARY canard)
 set(CANARD_INCLUDE ${CANARD_DIR})
@@ -26,11 +32,26 @@ set(CANARD_SOURCES
   ${CANARD_DIR}/canard.c
   ${CANARD_DIR}/canard.h
   ${CANARD_DIR}/canard_internals.h
-  ${CANARD_DIR}/drivers/stm32/canard_stm32.c
-  ${CANARD_DIR}/drivers/stm32/canard_stm32.h
-  ${CANARD_DIR}/drivers/stm32/_internal_bxcan.h
 )
+
+if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm")
+  list(APPEND CANARD_SOURCES
+    ${CANARD_DIR}/drivers/stm32/canard_stm32.c
+    ${CANARD_DIR}/drivers/stm32/canard_stm32.h
+    ${CANARD_DIR}/drivers/stm32/_internal_bxcan.h
+  )
+elseif("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
+  list(APPEND CANARD_SOURCES
+    ${CANARD_DIR}/drivers/socketcan/socketcan.c
+    ${CANARD_DIR}/drivers/socketcan/socketcan.h
+  )
+endif()
 
 add_library(${CANARD_LIBRARY} STATIC ${CANARD_SOURCES})
 target_include_directories(${CANARD_LIBRARY} PRIVATE ${CANARD_INCLUDE})
-target_include_directories(${CANARD_LIBRARY} PRIVATE ${CANARD_DIR}/drivers/stm32)
+
+if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm")
+  target_include_directories(${CANARD_LIBRARY} PRIVATE ${CANARD_DIR}/drivers/stm32)
+elseif("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
+  target_include_directories(${CANARD_LIBRARY} PRIVATE ${CANARD_DIR}/drivers/socketcan)
+endif()

--- a/CMakeLists_qpc.txt
+++ b/CMakeLists_qpc.txt
@@ -39,8 +39,8 @@ elseif("${CMAKE_ASM_COMPILER_ID}" MATCHES "Clang" AND "${CMAKE_SYSTEM_PROCESSOR}
     ${QPC_DIR}/${QP_PORT_DIR}/qk_port.c
     ${QPC_DIR}/src/qk/qk.c
   )
-elseif("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
-  message(STATUS "Building QP/C (qutest) for X86_64")
+else()
+  message(STATUS "Building QP/C (qutest) for X86")
   set(QP_PORT_DIR ports/posix)
   set(QPC_SOURCES
     ${QPC_DIR}/${QP_PORT_DIR}/qf_port.c

--- a/COPYING
+++ b/COPYING
@@ -34,16 +34,16 @@ License: MIT
 
 Files: dependencies/stm32cube/cmsis/*
 Copyright: 2009-2015 ARM LIMITED
-License: Custom Copyleft
+License: BSD-new
 
 Files: dependencies/stm32cube/cmsis/device/src/system_stm32f0xx.c
 Copyright: 2016 STMicroelectronics
-License: Custom Copyleft
+License: BSD-new
 
 Files: dependencies/stm32cube/hal/*
 Copyright: 2016-2018 STMicroelectronics
-License: Custom Copyleft
+License: BSD-new
 
 Files: dependencies/stm32cube/gnu/*
 Copyright: 2016-2018 STMicroelectronics
-License: Custom Copyleft
+License: BSD-new

--- a/COPYING.BSD-new
+++ b/COPYING.BSD-new
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) <author>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ The file `.clang-format` contains the options used to format this project's code
 
 **Note 1:** [SonarCloud](https://www.sonarsource.com/products/codeanalyzers/sonarcfamilyforcpp.html) is also used in the CI builds to check for compliance with [MISRA C rules](https://rules.sonarsource.com/c/tag/misra).
 
-**Note 2:** The QP™/C framework is MISRA C:2004 compliant, as described in [that project's compliance matrix](http://www.state-machine.com/doc/AN_QP-C_MISRA.pdf).
+**Note 2:** The QP™/C framework is MISRA C:2004 compliant to the extend described in [that project's compliance matrix](http://www.state-machine.com/doc/AN_QP-C_MISRA.pdf).
 
-**Note 3:** STMCube's HAL and LL are MISRA C:2004 compliant, as stated in page 1 of the UM1785 User Manual ("Description of STM32F0 HAL and low-layer drivers").
+**Note 3:** STM32CubeF0's HAL and LL are MISRA C:2004 compliant, with some exceptions, as stated in [STM32CubeF0's webpage](https://www.st.com/content/st_com/en/products/embedded-software/mcus-embedded-software/stm32-embedded-software/stm32cube-mcu-packages/stm32cubef0.html).
 
 ## License
 ![AGPL-3](https://www.gnu.org/graphics/agplv3-with-text-162x68.png)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ brew install armv6m-cortex-m0plus
 #### Linux
 Refer to `ci/Dockerfile`.
 
+For the test build, in Ubuntu Linux, install GCC multilib:
+
+```bash
+sudo dpkg --add-architecture i386
+sudo apt update
+sudo apt-get install libc6-dev:i386 gcc-multilib
+```
+
 ### Compiling the project
 
 1. Using GCC

--- a/dependencies/stm32cube/README.md
+++ b/dependencies/stm32cube/README.md
@@ -14,7 +14,6 @@ The STM32Cube's LL (Low Layer APIs) are not used in this project.
 - The file `cmsis/core/include/cmsis_gcc.h` was modified to silence a warning.
 
 ## Copying
-ARM's and ST's copylefts require that the project's documentation mentions the following text.
 
 ### ARM
 

--- a/doc/CAN.md
+++ b/doc/CAN.md
@@ -1,0 +1,34 @@
+## Tooling
+
+### Virtual CAN on Ubuntu Linux
+
+```bash
+sudo modprobe vcan
+sudo ip link add dev vcan0 type vcan
+sudo ip link set up vcan0
+```
+
+### CAN Utils on Ubuntu Linux
+
+#### Installation
+```bash
+sudo apt-get install can-utils
+```
+
+#### Listening for messages
+```bash
+candump vcan0
+```
+
+#### Sending a message
+The following command sends a message with identifier 0x1 and eight bytes of data `11223344556677AA`.
+```bash
+cansend vcan0 001#11223344556677AA
+```
+
+### UAVCAN GUI Tool on Ubuntu Linux
+```bash
+sudo apt-get install -y python3-pip python3-setuptools python3-wheel
+sudo apt-get install -y python3-numpy python3-pyqt5 python3-pyqt5.qtsvg git-core
+sudo -H pip3 install git+https://github.com/UAVCAN/gui_tool@master
+```


### PR DESCRIPTION
- Adds CMake instructions to build libcanard using the STM32 driver (for the PLC) or the SocketCAN driver (for the test builds).
- Indicates the correct license, BSD-new, for the STM32Cube dependencies.
- Adds some notes to the documentation regarding CAN bus tooling.